### PR TITLE
add freeProbParm function to all case cpp files

### DIFF
--- a/Exec/Plasma/FlameSheetIons/pelelmex_prob.cpp
+++ b/Exec/Plasma/FlameSheetIons/pelelmex_prob.cpp
@@ -18,3 +18,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Plasma/IonizedAirWave/pelelmex_prob.cpp
+++ b/Exec/Plasma/IonizedAirWave/pelelmex_prob.cpp
@@ -16,3 +16,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Plasma/PremBunsen3DKuhl/pelelmex_prob.cpp
+++ b/Exec/Plasma/PremBunsen3DKuhl/pelelmex_prob.cpp
@@ -37,3 +37,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Production/ChallengeProblem/pelelmex_prob.H
+++ b/Exec/Production/ChallengeProblem/pelelmex_prob.H
@@ -17,8 +17,6 @@
 #include <PMFData.H>
 #include <PelePhysics.H>
 
-#define PELE_PROB_PARM_NEEDS_FREEING
-
 // -----------------------------------------------------------
 // Search for the closest index in an array to a given value
 // using the bisection technique.

--- a/Exec/Production/CounterFlow/pelelmex_prob.cpp
+++ b/Exec/Production/CounterFlow/pelelmex_prob.cpp
@@ -30,3 +30,8 @@ PeleLM::readProbParm()
   pp.query("ignition_SphRad", PeleLM::prob_parm->ignitSphereRad);
   pp.query("ignition_SphT", PeleLM::prob_parm->ignitT);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/Production/CounterFlowSpray/pelelmex_prob.cpp
+++ b/Exec/Production/CounterFlowSpray/pelelmex_prob.cpp
@@ -21,3 +21,8 @@ PeleLM::readProbParm()
   pp.query("ignition_SphRad", PeleLM::prob_parm->ignitSphereRad);
   pp.query("ignition_SphT", PeleLM::prob_parm->ignitT);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/Production/DiffBunsen2D/pelelmex_prob.cpp
+++ b/Exec/Production/DiffBunsen2D/pelelmex_prob.cpp
@@ -44,3 +44,8 @@ PeleLM::readProbParm()
   pp.query("PhiV_y_lo", PeleLM::prob_parm->phiV_loy);
 #endif
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/Production/JetInCrossflow/pelelmex_prob.cpp
+++ b/Exec/Production/JetInCrossflow/pelelmex_prob.cpp
@@ -23,3 +23,8 @@ PeleLM::readProbParm()
   pp.query("jet_dir", PeleLM::prob_parm->jet_dir);
   pp.query("cf_dir", PeleLM::prob_parm->cf_dir);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.cpp
+++ b/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.cpp
@@ -64,3 +64,8 @@ PeleLM::readProbParm()
   prob_parm->center_xy[0] = 0.5 * (probhi[0] + problo[0]);
   prob_parm->center_xy[1] = 0.5 * (probhi[1] + problo[1]);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/Production/PremBunsen2D/pelelmex_prob.cpp
+++ b/Exec/Production/PremBunsen2D/pelelmex_prob.cpp
@@ -18,3 +18,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Production/PremBunsen3D/pelelmex_prob.cpp
+++ b/Exec/Production/PremBunsen3D/pelelmex_prob.cpp
@@ -16,3 +16,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Production/SwirlFlowWallInteractions/pelelmex_prob.cpp
+++ b/Exec/Production/SwirlFlowWallInteractions/pelelmex_prob.cpp
@@ -26,3 +26,9 @@ PeleLM::readProbParm()
   PeleLM::prob_parm->fuelID = CH4_ID;
   PeleLM::prob_parm->oxidID = O2_ID;
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/Production/TripleFlame/pelelmex_prob.cpp
+++ b/Exec/Production/TripleFlame/pelelmex_prob.cpp
@@ -25,3 +25,8 @@ PeleLM::readProbParm()
   PeleLM::prob_parm->fuelID = CH4_ID;
   PeleLM::prob_parm->oxidID = O2_ID;
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EB_BackwardStepFlame/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_BackwardStepFlame/pelelmex_prob.cpp
@@ -19,3 +19,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
     pp.query("ignition_temperature", prob_parm->ignition_temperature);
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EB_EnclosedFlame/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_EnclosedFlame/pelelmex_prob.cpp
@@ -15,3 +15,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/RegTests/EB_EnclosedVortex/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_EnclosedVortex/pelelmex_prob.cpp
@@ -23,3 +23,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
     PeleLM::trans_parms.sync_to_device();
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EB_FlowPastCylinder/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_FlowPastCylinder/pelelmex_prob.cpp
@@ -21,3 +21,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   //    PeleLM::trans_parms.sync_to_device();
   // }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EB_ODEQty/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_ODEQty/pelelmex_prob.cpp
@@ -23,3 +23,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   pp.query("extRhoYCO2", prob_parm->extRhoYCO2);
   pp.query("extRhoYCO2_ts", prob_parm->extRhoYCO2_ts);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EB_PipeFlow/pelelmex_prob.cpp
+++ b/Exec/RegTests/EB_PipeFlow/pelelmex_prob.cpp
@@ -25,3 +25,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   }
   */
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/EnclosedFlame/pelelmex_prob.cpp
+++ b/Exec/RegTests/EnclosedFlame/pelelmex_prob.cpp
@@ -12,3 +12,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/RegTests/EnclosedInjection/pelelmex_prob.cpp
+++ b/Exec/RegTests/EnclosedInjection/pelelmex_prob.cpp
@@ -13,3 +13,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   pp.query("jet_rad", prob_parm->jet_rad);
   pp.query("bl_thickness", prob_parm->bl_thickness);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/FlameSheet/pelelmex_prob.cpp
+++ b/Exec/RegTests/FlameSheet/pelelmex_prob.cpp
@@ -14,3 +14,9 @@ PeleLM::readProbParm()
   PeleLM::prob_parm->eosparm = PeleLM::eos_parms.device_parm();
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/RegTests/HotBubble/pelelmex_prob.cpp
+++ b/Exec/RegTests/HotBubble/pelelmex_prob.cpp
@@ -22,3 +22,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   pp.query("const_diffusivity", trans_parm.const_diffusivity);
   PeleLM::trans_parms.sync_to_device();
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/IsothermalSoretChannel/pelelmex_prob.cpp
+++ b/Exec/RegTests/IsothermalSoretChannel/pelelmex_prob.cpp
@@ -32,3 +32,8 @@ PeleLM::readProbParm()
     amrex::Abort("fuel_name not recognised!");
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/PeriodicCases/pelelmex_prob.cpp
+++ b/Exec/RegTests/PeriodicCases/pelelmex_prob.cpp
@@ -90,3 +90,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
     PeleLM::trans_parms.sync_to_device();
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/SootRadTest/pelelmex_prob.cpp
+++ b/Exec/RegTests/SootRadTest/pelelmex_prob.cpp
@@ -18,3 +18,9 @@ PeleLM::readProbParm()
     PeleLM::prob_parm->soot_vals[n] = moments[n];
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/RegTests/SprayTest/pelelmex_prob.cpp
+++ b/Exec/RegTests/SprayTest/pelelmex_prob.cpp
@@ -12,3 +12,8 @@ PeleLM::readProbParm()
   pp.query("init_N2", PeleLM::prob_parm->Y_N2);
   pp.query("init_O2", PeleLM::prob_parm->Y_O2);
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/TaylorGreen/pelelmex_prob.cpp
+++ b/Exec/RegTests/TaylorGreen/pelelmex_prob.cpp
@@ -56,3 +56,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   amrex::Print() << " mu [CGS] : " << trans_parm.const_viscosity << "\n";
   amrex::Print() << " #################################### \n";
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/TripleFlame/pelelmex_prob.cpp
+++ b/Exec/RegTests/TripleFlame/pelelmex_prob.cpp
@@ -25,3 +25,8 @@ PeleLM::readProbParm()
   PeleLM::prob_parm->fuelID = CH4_ID;
   PeleLM::prob_parm->oxidID = O2_ID;
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/TurbInflow/pelelmex_prob.cpp
+++ b/Exec/RegTests/TurbInflow/pelelmex_prob.cpp
@@ -24,3 +24,8 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   }
   */
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/RegTests/Unit/pelelmex_prob.cpp
+++ b/Exec/RegTests/Unit/pelelmex_prob.cpp
@@ -61,3 +61,8 @@ PeleLM::readProbParm()
     amrex::Abort();
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+}

--- a/Exec/UnitTests/DodecaneLu/pelelmex_prob.cpp
+++ b/Exec/UnitTests/DodecaneLu/pelelmex_prob.cpp
@@ -13,3 +13,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Exec/UnitTests/EB_SphericalFlame/pelelmex_prob.cpp
+++ b/Exec/UnitTests/EB_SphericalFlame/pelelmex_prob.cpp
@@ -16,3 +16,9 @@ PeleLM::readProbParm()
 
   PeleLM::pmf_data.initialize();
 }
+
+void
+PeleLM::freeProbParm()
+{
+  PeleLM::pmf_data.deallocate();
+}

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -28,9 +28,7 @@ PeleLM::~PeleLM()
 
   closeTempFile();
   typical_values.clear();
-#ifdef PELE_PROB_PARM_NEEDS_FREEING
   freeProbParm();
-#endif
   delete prob_parm;
   The_Arena()->free(prob_parm_d);
   m_initial_ba.clear();


### PR DESCRIPTION
Add definition of `PeleLM::freeProbParm()` to all case cpp files. In most cases, this function is a no-op. But it is needed if prob_parm contains dynamically allocated memory that needs to be freed, or if prob_parm intializes the pmf_data, which must then be deallocated at the end of the simulation (right now it looks like we don't do this anywhere).

These functions are not put in the ProblemSpecificFunctions struct because they need to be member functions of PeleLM to access various data structures (pmf_data, trans_parm, eos_parm, etc).